### PR TITLE
Support saving to write-only streams

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU1608;NU1109</NoWarn>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Excelsior is an Excel spreadsheet generation library with a distinctive data-driven approach.</Description>

--- a/src/ExcelsiorOpenXml.Tests/SaveAsWriteOnlyStreamTests.cs
+++ b/src/ExcelsiorOpenXml.Tests/SaveAsWriteOnlyStreamTests.cs
@@ -1,0 +1,36 @@
+[TestFixture]
+public class SaveAsWriteOnlyStreamTests
+{
+    [Test]
+    public async Task SaveAs_WriteOnlyStream()
+    {
+        var builder = new BookBuilder();
+        builder.AddSheet(SampleData.Employees());
+        using var book = await builder.Build();
+
+        var memoryStream = new MemoryStream();
+        await using var writeOnlyStream = new WriteOnlyStream(memoryStream);
+        book.SaveAs(writeOnlyStream);
+
+        Assert.That(memoryStream.Length, Is.GreaterThan(0));
+    }
+
+    class WriteOnlyStream(Stream inner) : Stream
+    {
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => inner.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+    }
+}

--- a/src/ExcelsiorOpenXml/OpenXmlBook.cs
+++ b/src/ExcelsiorOpenXml/OpenXmlBook.cs
@@ -26,7 +26,17 @@ public class OpenXmlBook : IDisposable
     public void SaveAs(Stream stream)
     {
         ApplyStylesheet();
-        Document.Clone(stream);
+        if (stream.CanRead)
+        {
+            Document.Clone(stream);
+        }
+        else
+        {
+            using var temp = new MemoryStream();
+            Document.Clone(temp);
+            temp.Position = 0;
+            temp.CopyTo(stream);
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
Make OpenXmlBook.SaveAs work with streams that are not readable by cloning the document into a temporary MemoryStream and copying it to the target when stream.CanRead is false. Adds SaveAsWriteOnlyStreamTests which verifies saving using a WriteOnlyStream wrapper to ensure the output is written to the underlying MemoryStream.