### PR TITLE
Add Redundant Column Heading analyzer

### DIFF
--- a/src/Excelsior.SourceGenerator.Tests/RedundantColumnHeadingAnalyzerTests.cs
+++ b/src/Excelsior.SourceGenerator.Tests/RedundantColumnHeadingAnalyzerTests.cs
@@ -1,0 +1,121 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[TestFixture]
+public class RedundantColumnHeadingAnalyzerTests
+{
+    [Test]
+    public void RedundantHeading_OnProperty()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Heading = "ReferenceNumber")]
+                public string ReferenceNumber { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(1, diagnostics.Length);
+        AreEqual("EXCEL001", diagnostics[0].Id);
+        IsTrue(diagnostics[0].GetMessage().Contains("ReferenceNumber"));
+    }
+
+    [Test]
+    public void RedundantHeading_OnRecordParameter()
+    {
+        var source = """
+            using Excelsior;
+
+            public record Order([Column(Heading = "Name")] string Name);
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(1, diagnostics.Length);
+        AreEqual("EXCEL001", diagnostics[0].Id);
+    }
+
+    [Test]
+    public void DifferentHeading_NoDiagnostic()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Heading = "Reference Number")]
+                public string ReferenceNumber { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(0, diagnostics.Length);
+    }
+
+    [Test]
+    public void NoHeading_NoDiagnostic()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Width = 15)]
+                public string ReferenceNumber { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(0, diagnostics.Length);
+    }
+
+    [Test]
+    public void NoColumnAttribute_NoDiagnostic()
+    {
+        var source = """
+            public class Order
+            {
+                public string ReferenceNumber { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(0, diagnostics.Length);
+    }
+
+    static ImmutableArray<Diagnostic> GetDiagnostics(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var trustedAssemblies = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(_ => MetadataReference.CreateFromFile(_))
+            .ToList();
+
+        var excelsiorRef = MetadataReference.CreateFromFile(
+            typeof(Excelsior.SheetModelAttribute).Assembly.Location);
+
+        var references = trustedAssemblies.Append(excelsiorRef);
+
+        var compilation = CSharpCompilation.Create(
+            "Tests",
+            [syntaxTree],
+            references,
+            new(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new Excelsior.SourceGenerator.RedundantColumnHeadingAnalyzer();
+
+        return compilation
+            .WithAnalyzers([analyzer])
+            .GetAnalyzerDiagnosticsAsync()
+            .GetAwaiter()
+            .GetResult();
+    }
+}

--- a/src/Excelsior.SourceGenerator/AnalyzerReleases.Shipped.md
+++ b/src/Excelsior.SourceGenerator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/Excelsior.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Excelsior.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,5 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+EXCEL001 | Excelsior.Usage | Warning | Redundant Column Heading

--- a/src/Excelsior.SourceGenerator/GlobalUsings.cs
+++ b/src/Excelsior.SourceGenerator/GlobalUsings.cs
@@ -1,3 +1,4 @@
 ﻿global using System.Collections.Immutable;
 global using Microsoft.CodeAnalysis;
 global using Microsoft.CodeAnalysis.CSharp.Syntax;
+global using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Excelsior.SourceGenerator/RedundantColumnHeadingAnalyzer.cs
+++ b/src/Excelsior.SourceGenerator/RedundantColumnHeadingAnalyzer.cs
@@ -1,0 +1,79 @@
+namespace Excelsior.SourceGenerator;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RedundantColumnHeadingAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Rule = new(
+        "EXCEL001",
+        "Redundant Column Heading",
+        "Heading \"{0}\" matches the property name; remove it to use the default heading",
+        "Excelsior.Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeProperty, SymbolKind.Property);
+        context.RegisterSymbolAction(AnalyzeParameter, SymbolKind.Parameter);
+    }
+
+    static void AnalyzeProperty(SymbolAnalysisContext context)
+    {
+        var property = (IPropertySymbol)context.Symbol;
+        AnalyzeSymbol(context, property.Name);
+    }
+
+    static void AnalyzeParameter(SymbolAnalysisContext context)
+    {
+        var parameter = (IParameterSymbol)context.Symbol;
+        AnalyzeSymbol(context, parameter.Name);
+    }
+
+    static void AnalyzeSymbol(SymbolAnalysisContext context, string memberName)
+    {
+        foreach (var attribute in context.Symbol.GetAttributes())
+        {
+            var attrClass = attribute.AttributeClass;
+            if (attrClass is null)
+            {
+                continue;
+            }
+
+            if (attrClass.Name != "ColumnAttribute" ||
+                attrClass.ContainingNamespace?.ToDisplayString() != "Excelsior")
+            {
+                continue;
+            }
+
+            foreach (var namedArg in attribute.NamedArguments)
+            {
+                if (namedArg.Key != "Heading")
+                {
+                    continue;
+                }
+
+                if (namedArg.Value.Value is not string heading)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(heading, memberName, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation();
+                if (location is null)
+                {
+                    continue;
+                }
+
+                context.ReportDiagnostic(Diagnostic.Create(Rule, location, heading));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce a Roslyn DiagnosticAnalyzer (EXCEL001) that warns when a ColumnAttribute's Heading named argument exactly matches the property or parameter name, encouraging removal of the redundant heading. The analyzer registers symbol actions for properties and parameters, checks attributes in the Excelsior namespace for a named "Heading" string, and reports a warning at the attribute location when the heading equals the member name.