### PR TITLE
WordTableBuilder: honor [Column(IsHtml = true)] in cell rendering

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2700,7 +2700,7 @@ var builder = new WordTableBuilder<Employee>(
         _.Font.Underline = true;
     });
 ```
-<sup><a href='/src/Excelsior.Tests/Word/WordTableBuilderTests.cs#L184-L197' title='Snippet source file'>snippet source</a> | <a href='#snippet-WordTableHeadingStyle' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/Word/WordTableBuilderTests.cs#L207-L220' title='Snippet source file'>snippet source</a> | <a href='#snippet-WordTableHeadingStyle' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 A per-column `HeadingStyle` on `ColumnConfig` composes on top of the table-level style, so individual headers can override or extend the shared look:
@@ -2715,7 +2715,7 @@ var builder = new WordTableBuilder<Employee>(
         _ => _.Name,
         _ => _.HeadingStyle = cell => cell.BackgroundColor = "FF0000");
 ```
-<sup><a href='/src/Excelsior.Tests/Word/WordTableBuilderTests.cs#L205-L214' title='Snippet source file'>snippet source</a> | <a href='#snippet-WordTableColumnHeadingStyle' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/Word/WordTableBuilderTests.cs#L228-L237' title='Snippet source file'>snippet source</a> | <a href='#snippet-WordTableColumnHeadingStyle' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Colors accept a leading `#` (e.g. `"#4472C4"`) and it will be stripped before being written to OpenXml.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU1608;NU1109</NoWarn>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Excelsior is an Excel spreadsheet generation library with a distinctive data-driven approach.</Description>

--- a/src/Excelsior.Tests/Word/WordTableBuilderTests.cs
+++ b/src/Excelsior.Tests/Word/WordTableBuilderTests.cs
@@ -163,6 +163,29 @@ public class WordTableBuilderTests
         AreEqual("Home", run.GetFirstChild<Text>()!.Text);
     }
 
+    public record HtmlRow
+    {
+        [Column(IsHtml = true)]
+        public required string Name { get; init; }
+    }
+
+    [Test]
+    public void IsHtmlColumnRendersInlineFormattingAsRunProperties()
+    {
+        var rows = new[]
+        {
+            new HtmlRow { Name = "<i>A. Smith</i>" }
+        };
+
+        var table = new WordTableBuilder<HtmlRow>(rows).Build();
+
+        var dataCell = table.Elements<TableRow>().Skip(1).First().GetFirstChild<TableCell>()!;
+        var paragraph = dataCell.GetFirstChild<Paragraph>()!;
+        var run = paragraph.GetFirstChild<Run>()!;
+        IsNotNull(run.RunProperties!.GetFirstChild<Italic>());
+        AreEqual("A. Smith", run.GetFirstChild<Text>()!.Text);
+    }
+
     [Test]
     public void FormulaColumnThrows()
     {

--- a/src/Excelsior/Word/WordTableRenderer.cs
+++ b/src/Excelsior/Word/WordTableRenderer.cs
@@ -326,13 +326,19 @@ static class WordTableRenderer<TModel>
         foreach (var column in columns)
         {
             var value = column.GetValue(item);
-            row.Append(new W.TableCell(BuildCellParagraph(column, item, value, mainPart)));
+            var cell = new W.TableCell();
+            foreach (var paragraph in BuildCellParagraphs(column, item, value, mainPart))
+            {
+                cell.Append(paragraph);
+            }
+
+            row.Append(cell);
         }
 
         return row;
     }
 
-    static W.Paragraph BuildCellParagraph(
+    static IReadOnlyList<W.Paragraph> BuildCellParagraphs(
         ColumnConfig<TModel> column,
         TModel item,
         object? value,
@@ -349,16 +355,27 @@ static class WordTableRenderer<TModel>
         // fall through to the plain-text path which renders link.Text ?? link.Url.
         if (value is Link link && mainPart != null)
         {
-            return BuildHyperlinkParagraph(link, mainPart);
+            return [BuildHyperlinkParagraph(link, mainPart)];
         }
 
         var text = ToText(column, item, value);
-        return new(
-            new W.Run(
-                new W.Text(text)
-                {
-                    Space = SpaceProcessingModeValues.Preserve
-                }));
+
+        // IsHtml columns route through WordHtmlConverter so inline tags (<i>, <b>, <a>, etc.) and
+        // block elements (<p>, <ul>, ...) become proper runs/paragraphs instead of literal text.
+        if (column.IsHtml)
+        {
+            return WordHtmlConverter.ToParagraphs(text, mainPart);
+        }
+
+        return
+        [
+            new(
+                new W.Run(
+                    new W.Text(text)
+                    {
+                        Space = SpaceProcessingModeValues.Preserve
+                    }))
+        ];
     }
 
     static W.Paragraph BuildHyperlinkParagraph(Link link, MainDocumentPart mainPart)


### PR DESCRIPTION
  Cells with IsHtml route through WordHtmlConverter.ToParagraphs so inline
  tags (<i>, <b>, <a>, ...) and block elements (<p>, <ul>, ...) become real
  runs and paragraphs instead of literal text. Previously matched the
  spreadsheet path's behavior only.