### PR TITLE
Suppress "unused property" warnings on [Column] / [SheetModel] members

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1896,9 +1896,12 @@ It is intended as the preferred approach over usage of `DisplayAttribute` and `D
 <!-- snippet: ColumnAttribute.cs -->
 <a id='snippet-ColumnAttribute.cs'></a>
 ```cs
+using JetBrains.Annotations;
+
 namespace Excelsior;
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+[MeansImplicitUse]
 public sealed class ColumnAttribute :
     Attribute
 {
@@ -1947,7 +1950,7 @@ public sealed class ColumnAttribute :
     internal bool IncludeHasValue { get; private set; }
 }
 ```
-<sup><a href='/src/Excelsior/Attributes/ColumnAttribute.cs#L1-L50' title='Snippet source file'>snippet source</a> | <a href='#snippet-ColumnAttribute.cs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior/Attributes/ColumnAttribute.cs#L1-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-ColumnAttribute.cs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Excelsior/Attributes/ColumnAttribute.cs
+++ b/src/Excelsior/Attributes/ColumnAttribute.cs
@@ -1,6 +1,9 @@
+using JetBrains.Annotations;
+
 namespace Excelsior;
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Parameter)]
+[MeansImplicitUse]
 public sealed class ColumnAttribute :
     Attribute
 {

--- a/src/Excelsior/Attributes/JetBrainsAnnotations.cs
+++ b/src/Excelsior/Attributes/JetBrainsAnnotations.cs
@@ -1,0 +1,24 @@
+// Internal stubs of JetBrains.Annotations attributes. ReSharper / Rider recognise these by
+// namespace + name match against metadata, regardless of which assembly they live in — so
+// shipping our own internal copy lets us decorate ColumnAttribute with [MeansImplicitUse]
+// without taking a dependency on the JetBrains.Annotations NuGet package. Users may freely
+// also reference that package; the internal scope here prevents type-resolution conflicts.
+namespace JetBrains.Annotations;
+
+[AttributeUsage(AttributeTargets.Class)]
+sealed class MeansImplicitUseAttribute(
+    ImplicitUseTargetFlags targetFlags = ImplicitUseTargetFlags.Default) :
+    Attribute
+{
+    public ImplicitUseTargetFlags TargetFlags { get; } = targetFlags;
+}
+
+[Flags]
+enum ImplicitUseTargetFlags
+{
+    Default = Itself,
+    Itself = 1,
+    Members = 2,
+    WithInheritors = 4,
+    WithMembers = Itself | Members,
+}

--- a/src/Excelsior/Attributes/SheetModelAttribute.cs
+++ b/src/Excelsior/Attributes/SheetModelAttribute.cs
@@ -1,7 +1,10 @@
+using JetBrains.Annotations;
+
 namespace Excelsior;
 
 [AttributeUsage(
     AttributeTargets.Class |
     AttributeTargets.Struct)]
+[MeansImplicitUse(ImplicitUseTargetFlags.Members)]
 public sealed class SheetModelAttribute :
     Attribute;


### PR DESCRIPTION
  Add internal JetBrains.Annotations stubs and decorate ColumnAttribute with
  [MeansImplicitUse], and SheetModelAttribute with
  [MeansImplicitUse(ImplicitUseTargetFlags.Members)], so ReSharper/Rider treat
  attributed properties (and all members of a [SheetModel] type) as implicitly
  used. Mirrors the approach used in Parchment; no new NuGet dependency.