### PR TITLE
error on unrecognized header columns during import

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -353,7 +353,12 @@ var reader = new BookReader();
 var staff = reader.AddSheet("Staff");
 staff
     .Column<int>("Employee ID")
-    .Column<string>("Full Name");
+    .Column<string>("Full Name")
+    .Column<string>("Email Address")
+    .Column<Date?>("Hire Date")
+    .Column<int>("Annual Salary")
+    .Column<bool>("IsActive")
+    .Column<EmployeeStatus>("Status");
 
 var departments = reader.AddSheet("Departments");
 departments
@@ -367,10 +372,10 @@ Assert.That(staff.Rows[0]["Full Name"], Is.EqualTo("John Doe"));
 Assert.That(departments.Rows.Select(_ => _["Name"]), Is.EqualTo(new object[] { "Eng", "Sales" }));
 Assert.That(departments.Rows.Select(_ => _["HeadCount"]), Is.EqualTo(new object[] { 12, 7 }));
 ```
-<sup><a href='/src/Excelsior.Tests/Reading/BookReaderAnonymousTests.cs#L62-L82' title='Snippet source file'>snippet source</a> | <a href='#snippet-BookReaderDictionaryMultipleSheets' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/Reading/BookReaderAnonymousTests.cs#L62-L87' title='Snippet source file'>snippet source</a> | <a href='#snippet-BookReaderDictionaryMultipleSheets' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-If a sheet's declared columns don't match what's in the file, that sheet's row parsing is skipped (one error per missing column is recorded against it), but subsequent sheets are still processed. Per-row parse errors don't have this short-circuit — they are collected per failing cell.
+If a sheet's declared columns don't match what's in the file, that sheet's row parsing is skipped (one error per missing column, plus one error per unrecognized header column, is recorded against it), but subsequent sheets are still processed. Per-row parse errors don't have this short-circuit — they are collected per failing cell.
 
 
 #### Per-cell delegate conversion

--- a/src/Excelsior.Tests/Reading/BookReaderAnonymousTests.cs
+++ b/src/Excelsior.Tests/Reading/BookReaderAnonymousTests.cs
@@ -66,7 +66,12 @@ public class BookReaderAnonymousTests
         var staff = reader.AddSheet("Staff");
         staff
             .Column<int>("Employee ID")
-            .Column<string>("Full Name");
+            .Column<string>("Full Name")
+            .Column<string>("Email Address")
+            .Column<Date?>("Hire Date")
+            .Column<int>("Annual Salary")
+            .Column<bool>("IsActive")
+            .Column<EmployeeStatus>("Status");
 
         var departments = reader.AddSheet("Departments");
         departments

--- a/src/Excelsior.Tests/Reading/BookReaderErrorTests.cs
+++ b/src/Excelsior.Tests/Reading/BookReaderErrorTests.cs
@@ -154,16 +154,17 @@ public class BookReaderErrorTests
         sheet.Column<string>("Nope");
 
         var exception = Assert.Throws<ReadException>(() => reader.Convert(stream))!;
-        Assert.That(exception.Errors, Has.Count.EqualTo(1));
-        Assert.That(exception.Errors[0].ColumnName, Is.EqualTo("Nope"));
+        Assert.That(exception.Errors, Has.Count.EqualTo(2));
+        Assert.That(exception.Errors.Any(_ => _.ColumnName == "Nope" && _.Message.Contains("not found")));
+        Assert.That(exception.Errors.Any(_ => _.Message.Contains("Unrecognized header 'A'")));
     }
 
     [Test]
     public async Task ColumnMismatch_StopsBeforeRowParsing_NoPerCellErrors()
     {
-        // OneCol writes string "x"; reader expects an int "Value" column that
-        // doesn't exist. Should produce exactly one column-mismatch error and
-        // skip row parsing entirely.
+        // OneCol writes string "A"; reader expects an int "Value" column that
+        // doesn't exist. Should produce one missing-column error plus one
+        // unrecognized-header error and skip row parsing entirely.
         var stream = await Write<OneCol>(
             new() { A = "x" },
             new() { A = "y" },
@@ -174,8 +175,9 @@ public class BookReaderErrorTests
         sheet.Column<int>("Value");
 
         var exception = Assert.Throws<ReadException>(() => reader.Convert(stream))!;
-        Assert.That(exception.Errors, Has.Count.EqualTo(1));
-        Assert.That(exception.Errors[0].ColumnName, Is.EqualTo("Value"));
+        Assert.That(exception.Errors, Has.Count.EqualTo(2));
+        Assert.That(exception.Errors.Any(_ => _.ColumnName == "Value" && _.Message.Contains("not found")));
+        Assert.That(exception.Errors.Any(_ => _.Message.Contains("Unrecognized header 'A'")));
         Assert.That(sheet.Rows, Is.Empty);
     }
 

--- a/src/Excelsior/Reading/SheetParser.cs
+++ b/src/Excelsior/Reading/SheetParser.cs
@@ -91,7 +91,7 @@ static class SheetParser
             if (!headerSeen)
             {
                 headerSeen = true;
-                var columnByIndex = ResolveColumnByIndex(row, sharedStrings, metadataColumnMap, byName, byHeading);
+                var columnByIndex = ResolveColumnByIndex(row, sharedStrings, metadataColumnMap, byName, byHeading, out var unmatchedHeaders);
 
                 var resolvedNames = new HashSet<string>(StringComparer.Ordinal);
                 foreach (var info in columnByIndex.Values)
@@ -113,6 +113,16 @@ static class SheetParser
                         declared.Name,
                         CellReference: "",
                         $"Column '{declared.Name}' (heading '{declared.Heading}') was not found in the sheet header row."));
+                }
+
+                foreach (var (cellRef, headerText) in unmatchedHeaders)
+                {
+                    errors.Add(new(
+                        resolvedSheetName,
+                        RowIndex: (int)(row.RowIndex?.Value ?? 0),
+                        ColumnName: "",
+                        CellReference: cellRef,
+                        $"Unrecognized header '{headerText}' — no declared column matches this heading."));
                 }
 
                 if (errors.Count > beforeCount)
@@ -174,9 +184,11 @@ static class SheetParser
         string?[]? sharedStrings,
         Dictionary<int, string>? metadataColumnMap,
         Dictionary<string, ColumnReadInfo> byName,
-        Dictionary<string, ColumnReadInfo> byHeading)
+        Dictionary<string, ColumnReadInfo> byHeading,
+        out List<(string CellReference, string HeaderText)> unmatchedHeaders)
     {
         var result = new Dictionary<int, ColumnReadInfo>();
+        unmatchedHeaders = [];
 
         foreach (var cell in headerRow.Elements<Cell>())
         {
@@ -198,7 +210,7 @@ static class SheetParser
             }
 
             var headerText = CellConverter.ReadRaw(cell, sharedStrings);
-            if (headerText == null)
+            if (string.IsNullOrWhiteSpace(headerText))
             {
                 continue;
             }
@@ -214,7 +226,10 @@ static class SheetParser
             if (byName.TryGetValue(headerText, out var byPlainName))
             {
                 result[index] = byPlainName;
+                continue;
             }
+
+            unmatchedHeaders.Add((cell.CellReference?.Value ?? "", headerText));
         }
 
         return result;


### PR DESCRIPTION
  Each header cell in the imported sheet that doesn't match a declared
  column (by metadata, heading, or property name) now produces a ReadError,
  alongside the existing missing-column errors. Subset-reading is no
  longer supported — readers must declare every column present in the file.