### PR TITLE
Validate Include = false is not combined with other column settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2169,9 +2169,70 @@ public sealed class ColumnAttribute :
     } = true;
 
     internal bool IncludeHasValue { get; private set; }
+
+    /// <summary>
+    /// When <see cref="Include"/> is explicitly <c>false</c> the column is dropped before
+    /// any other setting is read, so every other setting is silently ignored. Returns the
+    /// names of any such redundant settings (empty when there is no conflict).
+    /// </summary>
+    internal IReadOnlyList<string> ConflictingExclusionSettings()
+    {
+        if (!IncludeHasValue || Include)
+        {
+            return [];
+        }
+
+        var conflicts = new List<string>();
+        if (Heading != null)
+        {
+            conflicts.Add(nameof(Heading));
+        }
+
+        if (Order > -1)
+        {
+            conflicts.Add(nameof(Order));
+        }
+
+        if (Width > -1)
+        {
+            conflicts.Add(nameof(Width));
+        }
+
+        if (MinWidth > -1)
+        {
+            conflicts.Add(nameof(MinWidth));
+        }
+
+        if (MaxWidth > -1)
+        {
+            conflicts.Add(nameof(MaxWidth));
+        }
+
+        if (Format != null)
+        {
+            conflicts.Add(nameof(Format));
+        }
+
+        if (NullDisplay != null)
+        {
+            conflicts.Add(nameof(NullDisplay));
+        }
+
+        if (IsHtmlHasValue)
+        {
+            conflicts.Add(nameof(IsHtml));
+        }
+
+        if (FilterHasValue)
+        {
+            conflicts.Add(nameof(Filter));
+        }
+
+        return conflicts;
+    }
 }
 ```
-<sup><a href='/src/Excelsior/Attributes/ColumnAttribute.cs#L1-L53' title='Snippet source file'>snippet source</a> | <a href='#snippet-ColumnAttribute.cs' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior/Attributes/ColumnAttribute.cs#L1-L114' title='Snippet source file'>snippet source</a> | <a href='#snippet-ColumnAttribute.cs' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -2636,7 +2697,7 @@ var builder = new BookBuilder();
 var sheet = builder.AddSheet(data);
 sheet.Include(_ => _.Email, !isInternalReport);
 ```
-<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L83-L92' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeToggleBasedOnState' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L101-L110' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeToggleBasedOnState' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -2660,7 +2721,7 @@ var sheet = builder.AddSheet(data);
 sheet.Exclude(_ => _.Age);
 sheet.Exclude(_ => _.Email);
 ```
-<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L101-L111' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeMultipleSpreadsheets_Public' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L119-L129' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeMultipleSpreadsheets_Public' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -2680,7 +2741,7 @@ List<Target> data = [
 var builder = new BookBuilder();
 builder.AddSheet(data);
 ```
-<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L120-L131' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeMultipleSpreadsheets_Internal' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L138-L149' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeMultipleSpreadsheets_Internal' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -2702,7 +2763,7 @@ var builder = new BookBuilder();
 var sheet = builder.AddSheet(data);
 sheet.Exclude(_ => _.Age);
 ```
-<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L29-L39' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeExcludeOne' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L34-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeExcludeOne' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -2726,7 +2787,7 @@ sheet.Column(
     _ => _.Age,
     _ => _.Include = false);
 ```
-<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L48-L60' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeExcludeOneViaColumn' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Excelsior.Tests/IncludeTests.cs#L53-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-IncludeExcludeOneViaColumn' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;NU1608;NU1109</NoWarn>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <LangVersion>14.0</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <Description>Excelsior is an Excel spreadsheet generation library with a distinctive data-driven approach.</Description>

--- a/src/Excelsior.SourceGenerator.Tests/ExcludedColumnSettingsAnalyzerTests.cs
+++ b/src/Excelsior.SourceGenerator.Tests/ExcludedColumnSettingsAnalyzerTests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[TestFixture]
+public class ExcludedColumnSettingsAnalyzerTests
+{
+    [Test]
+    public void ExcludeWithWidth_OnProperty()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Include = false, Width = 40)]
+                public string Notes { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(1, diagnostics.Length);
+        AreEqual("EXCEL004", diagnostics[0].Id);
+    }
+
+    [Test]
+    public void ExcludeWithHeading_OnRecordParameter()
+    {
+        var source = """
+            using Excelsior;
+
+            public record Order([Column(Include = false, Heading = "X")] string Notes);
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(1, diagnostics.Length);
+        AreEqual("EXCEL004", diagnostics[0].Id);
+    }
+
+    [Test]
+    public void ExcludeWithFormat_OnField()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Include = false, Format = "0.00")]
+                public decimal Total;
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(1, diagnostics.Length);
+        AreEqual("EXCEL004", diagnostics[0].Id);
+    }
+
+    [Test]
+    public void ExcludeAlone_NoDiagnostic()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Include = false)]
+                public string Notes { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(0, diagnostics.Length);
+    }
+
+    [Test]
+    public void IncludedWithSettings_NoDiagnostic()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Width = 40, Heading = "X")]
+                public string Notes { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(0, diagnostics.Length);
+    }
+
+    [Test]
+    public void ExplicitIncludeTrueWithSettings_NoDiagnostic()
+    {
+        var source = """
+            using Excelsior;
+
+            public class Order
+            {
+                [Column(Include = true, Width = 40)]
+                public string Notes { get; set; }
+            }
+            """;
+
+        var diagnostics = GetDiagnostics(source);
+
+        AreEqual(0, diagnostics.Length);
+    }
+
+    static ImmutableArray<Diagnostic> GetDiagnostics(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+
+        var trustedAssemblies = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(_ => MetadataReference.CreateFromFile(_))
+            .ToList();
+
+        var excelsiorRef = MetadataReference.CreateFromFile(
+            typeof(Excelsior.SheetModelAttribute).Assembly.Location);
+
+        var references = trustedAssemblies.Append(excelsiorRef);
+
+        var compilation = CSharpCompilation.Create(
+            "Tests",
+            [syntaxTree],
+            references,
+            new(OutputKind.DynamicallyLinkedLibrary));
+
+        var analyzer = new Excelsior.SourceGenerator.ExcludedColumnSettingsAnalyzer();
+
+        return compilation
+            .WithAnalyzers([analyzer])
+            .GetAnalyzerDiagnosticsAsync()
+            .GetAwaiter()
+            .GetResult();
+    }
+}

--- a/src/Excelsior.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/Excelsior.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,4 @@ Rule ID | Category | Severity | Notes
 EXCEL001 | Excelsior.Usage | Warning | Redundant Column Heading
 EXCEL002 | Excelsior | Error | SheetModel type is not accessible
 EXCEL003 | Excelsior.Usage | Error | Mismatched IsHtml
+EXCEL004 | Excelsior.Usage | Error | Excluded column has redundant settings

--- a/src/Excelsior.SourceGenerator/ExcludedColumnSettingsAnalyzer.cs
+++ b/src/Excelsior.SourceGenerator/ExcludedColumnSettingsAnalyzer.cs
@@ -1,0 +1,121 @@
+namespace Excelsior.SourceGenerator;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ExcludedColumnSettingsAnalyzer : DiagnosticAnalyzer
+{
+    public static readonly DiagnosticDescriptor Rule = new(
+        "EXCEL004",
+        "Excluded column has redundant settings",
+        "[Column(Include = false)] cannot be combined with other column settings ({0}); an excluded column is never written, so those settings have no effect",
+        "Excelsior.Usage",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(start =>
+        {
+            var columnAttributeType = start.Compilation
+                .GetTypeByMetadataName("Excelsior.ColumnAttribute");
+            if (columnAttributeType is null)
+            {
+                return;
+            }
+
+            start.RegisterSymbolAction(
+                _ => AnalyzeMember(_, columnAttributeType),
+                SymbolKind.Property);
+            start.RegisterSymbolAction(
+                _ => AnalyzeMember(_, columnAttributeType),
+                SymbolKind.Field);
+            start.RegisterSymbolAction(
+                _ => AnalyzeMember(_, columnAttributeType),
+                SymbolKind.Parameter);
+        });
+    }
+
+    static void AnalyzeMember(SymbolAnalysisContext context, INamedTypeSymbol columnAttributeType)
+    {
+        foreach (var attribute in context.Symbol.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, columnAttributeType))
+            {
+                continue;
+            }
+
+            if (!IsExcluded(attribute))
+            {
+                continue;
+            }
+
+            var conflicts = Conflicts(attribute);
+            if (conflicts.Count == 0)
+            {
+                continue;
+            }
+
+            var location = attribute.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation();
+            if (location is null)
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, location, string.Join(", ", conflicts)));
+        }
+    }
+
+    static bool IsExcluded(AttributeData attribute)
+    {
+        foreach (var named in attribute.NamedArguments)
+        {
+            if (named is { Key: "Include", Value.Value: false })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Canonical order, matching ColumnAttribute.ConflictingExclusionSettings.
+    static readonly string[] settingOrder =
+    [
+        "Heading",
+        "Order",
+        "Width",
+        "MinWidth",
+        "MaxWidth",
+        "Format",
+        "NullDisplay",
+        "IsHtml",
+        "Filter"
+    ];
+
+    static List<string> Conflicts(AttributeData attribute)
+    {
+        var present = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var named in attribute.NamedArguments)
+        {
+            if (IsSet(named.Key, named.Value.Value))
+            {
+                present.Add(named.Key);
+            }
+        }
+
+        return settingOrder.Where(present.Contains).ToList();
+    }
+
+    static bool IsSet(string key, object? value) =>
+        key switch
+        {
+            "Heading" or "Format" or "NullDisplay" => value is string,
+            "Order" or "Width" or "MinWidth" or "MaxWidth" => value is int and > -1,
+            "IsHtml" or "Filter" => true,
+            _ => false
+        };
+}

--- a/src/Excelsior.Tests/IncludeTests.cs
+++ b/src/Excelsior.Tests/IncludeTests.cs
@@ -7,6 +7,11 @@ public class IncludeTests
     // ReSharper disable once NotAccessedPositionalProperty.Local
     record AttributeIncludeFalseTarget(string Name, [Column(Include = false)] int Age, string Email);
 
+#pragma warning disable EXCEL004
+    // ReSharper disable once NotAccessedPositionalProperty.Local
+    record ExcludeWithOtherSettingsTarget(string Name, [Column(Include = false, Width = 40)] int Age, string Email);
+#pragma warning restore EXCEL004
+
     static List<Target> Data() =>
     [
         new("Alice", 30, "alice@test.com"),
@@ -75,6 +80,19 @@ public class IncludeTests
 
         var book = await builder.Build();
         await Verify(book);
+    }
+
+    [Test]
+    public void ExcludeCombinedWithOtherSettingsThrows()
+    {
+        var builder = new BookBuilder();
+
+        var exception = Assert.Catch(
+            () => builder.AddSheet(new List<ExcludeWithOtherSettingsTarget>()));
+
+        var inner = exception is TypeInitializationException tie ? tie.InnerException! : exception;
+        Assert.That(inner!.Message, Does.Contain("Include = false"));
+        Assert.That(inner.Message, Does.Contain("Width"));
     }
 
     [Test]

--- a/src/Excelsior/Attributes/ColumnAttribute.cs
+++ b/src/Excelsior/Attributes/ColumnAttribute.cs
@@ -50,4 +50,65 @@ public sealed class ColumnAttribute :
     } = true;
 
     internal bool IncludeHasValue { get; private set; }
+
+    /// <summary>
+    /// When <see cref="Include"/> is explicitly <c>false</c> the column is dropped before
+    /// any other setting is read, so every other setting is silently ignored. Returns the
+    /// names of any such redundant settings (empty when there is no conflict).
+    /// </summary>
+    internal IReadOnlyList<string> ConflictingExclusionSettings()
+    {
+        if (!IncludeHasValue || Include)
+        {
+            return [];
+        }
+
+        var conflicts = new List<string>();
+        if (Heading != null)
+        {
+            conflicts.Add(nameof(Heading));
+        }
+
+        if (Order > -1)
+        {
+            conflicts.Add(nameof(Order));
+        }
+
+        if (Width > -1)
+        {
+            conflicts.Add(nameof(Width));
+        }
+
+        if (MinWidth > -1)
+        {
+            conflicts.Add(nameof(MinWidth));
+        }
+
+        if (MaxWidth > -1)
+        {
+            conflicts.Add(nameof(MaxWidth));
+        }
+
+        if (Format != null)
+        {
+            conflicts.Add(nameof(Format));
+        }
+
+        if (NullDisplay != null)
+        {
+            conflicts.Add(nameof(NullDisplay));
+        }
+
+        if (IsHtmlHasValue)
+        {
+            conflicts.Add(nameof(IsHtml));
+        }
+
+        if (FilterHasValue)
+        {
+            conflicts.Add(nameof(Filter));
+        }
+
+        return conflicts;
+    }
 }

--- a/src/Excelsior/Property.cs
+++ b/src/Excelsior/Property.cs
@@ -17,6 +17,7 @@ class Property<T>
         if (generated is null)
         {
             var column = info.Attribute<ColumnAttribute>() ?? constructorParameter?.Attribute<ColumnAttribute>();
+            ValidateExclusion(info, column);
             Order = GetOrder(column, display);
             Width = GetWidth(column);
             MinWidth = GetMinWidth(column);
@@ -45,6 +46,22 @@ class Property<T>
         IsNumber = Type.IsNumericType();
         IsNonNullable = ResolveIsNonNullable(info);
         IsRequired = ResolveIsRequired(info, constructorParameter);
+    }
+
+    static void ValidateExclusion(MemberInfo info, ColumnAttribute? column)
+    {
+        if (column is null)
+        {
+            return;
+        }
+
+        var conflicts = column.ConflictingExclusionSettings();
+        if (conflicts.Count == 0)
+        {
+            return;
+        }
+
+        throw new($"Property '{info.DeclaringType!.Name}.{info.Name}': [Column(Include = false)] cannot be combined with other column settings ({string.Join(", ", conflicts)}) — an excluded column is never written, so those settings have no effect.");
     }
 
     static bool ResolveIsRequired(MemberInfo info, ParameterInfo? constructorParameter)


### PR DESCRIPTION
Validate Include = false is not combined with other column settings Excluding a column drops it before any other [Column] setting is read, so Heading/Order/Width/Format/etc. are silently ignored. Now flagged both ways:
- EXCEL004 analyzer (error) on any [Column(Include = false)] combined with other settings
- runtime throw on the reflection path via ColumnAttribute.ConflictingExclusionSettings