### PR TITLE
Resolve `new`-shadowed members to the most-derived declaration

### DIFF
--- a/src/Excelsior.Tests/PropertiesTests.cs
+++ b/src/Excelsior.Tests/PropertiesTests.cs
@@ -433,4 +433,29 @@ public class PropertiesTests
     [Test]
     public Task SplitParameter() =>
         Verify(Properties<ModelWithSplitParameter>.Items);
+
+    class ShadowBase
+    {
+        public string Kept { get; set; } = "";
+        public int Detail { get; set; }
+    }
+
+    class ShadowDerived : ShadowBase
+    {
+        public new string Detail { get; set; } = "";
+    }
+
+    [Test]
+    public void Properties_NewShadowedMemberKeepsMostDerived()
+    {
+        var items = Properties<ShadowDerived>.Items;
+
+        // Reflection surfaces both the base int and the `new` string Detail; only the most-derived
+        // (string) survives, so column registration neither crashes on the duplicate name nor binds
+        // the hidden base member.
+        var detail = items.Where(_ => _.Name == "Detail").ToList();
+        Assert.That(detail, Has.Count.EqualTo(1));
+        Assert.That(detail[0].Type, Is.EqualTo(typeof(string)));
+        Assert.That(items, Has.Some.Matches<Property<ShadowDerived>>(_ => _.Name == "Kept"));
+    }
 }

--- a/src/Excelsior.Tests/Reading/BookReaderPrimitivesTests.cs
+++ b/src/Excelsior.Tests/Reading/BookReaderPrimitivesTests.cs
@@ -371,4 +371,25 @@ public class BookReaderPrimitivesTests
     {
         public SampleEnum? Value { get; set; }
     }
+
+    [Test]
+    public async Task NewShadowedMember()
+    {
+        // A `new`-shadowed member surfaces twice via reflection. Writing must not crash on the
+        // duplicate name, and the most-derived declaration must win on both write and read.
+        var rows = await RoundTrip(new ShadowDerived {Kept = "k", Detail = "shadowed"});
+        Assert.That(rows[0].Kept, Is.EqualTo("k"));
+        Assert.That(rows[0].Detail, Is.EqualTo("shadowed"));
+    }
+
+    public class ShadowBase
+    {
+        public string Kept { get; set; } = "";
+        public int Detail { get; set; }
+    }
+
+    public class ShadowDerived : ShadowBase
+    {
+        public new string Detail { get; set; } = "";
+    }
 }

--- a/src/Excelsior/Extensions.cs
+++ b/src/Excelsior/Extensions.cs
@@ -67,6 +67,16 @@
             };
     }
 
+    // type.GetProperties/GetFields return inherited members, so a `new`-shadowed member (or one that
+    // hides a base member of the same name) appears more than once. Keep the most-derived
+    // declaration — the member a `T` reference actually binds to — so the duplicate neither crashes
+    // column registration (Dictionary.Add) nor silently resolves to the hidden base member.
+    public static IEnumerable<MemberInfo> DistinctByMostDerived(this IEnumerable<MemberInfo> members) =>
+        members
+            .GroupBy(_ => _.Name)
+            .Select(_ => _.Aggregate(
+                (most, candidate) => most.DeclaringType!.IsAssignableFrom(candidate.DeclaringType!) ? candidate : most));
+
     public static bool IsNumericType(this Type type)
     {
         if (type.IsEnum)

--- a/src/Excelsior/Properties.cs
+++ b/src/Excelsior/Properties.cs
@@ -45,18 +45,11 @@ static class Properties<T>
     static IEnumerable<MemberInfo> GetReadableMembers(Type type)
     {
         const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
-        foreach (var property in type.GetProperties(flags))
-        {
-            if (property.IsReadable)
-            {
-                yield return property;
-            }
-        }
-
-        foreach (var field in type.GetFields(flags))
-        {
-            yield return field;
-        }
+        return type.GetProperties(flags)
+            .Where(_ => _.IsReadable)
+            .Cast<MemberInfo>()
+            .Concat(type.GetFields(flags))
+            .DistinctByMostDerived();
     }
 
     static bool ShouldSplit(MemberInfo member, ParameterInfo? parameter, out bool useHierachyForName)

--- a/src/Excelsior/Reading/ModelActivator.cs
+++ b/src/Excelsior/Reading/ModelActivator.cs
@@ -56,30 +56,21 @@ static class ModelActivator<T>
     {
         const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
         var result = new Dictionary<string, Action<T, object?>>(StringComparer.Ordinal);
-        foreach (var property in type.GetProperties(flags))
+        // Dedup `new`-shadowed members to the most-derived declaration so a hidden base member of
+        // the same name doesn't clobber the setter (e.g. a base `int` shadowed by a derived `string`).
+        var members = type.GetProperties(flags)
+            .Where(_ => _.IsWritable)
+            .Cast<MemberInfo>()
+            .Concat(type.GetFields(flags).Where(_ => _.IsWritable))
+            .DistinctByMostDerived();
+        foreach (var member in members)
         {
-            if (!property.IsWritable)
+            result[member.Name] = member switch
             {
-                continue;
-            }
-
-            var setter = property.SetMethod;
-            if (setter == null)
-            {
-                continue;
-            }
-
-            result[property.Name] = BuildPropertySetter(property, setter);
-        }
-
-        foreach (var field in type.GetFields(flags))
-        {
-            if (!field.IsWritable)
-            {
-                continue;
-            }
-
-            result[field.Name] = BuildFieldSetter(field);
+                PropertyInfo property => BuildPropertySetter(property, property.SetMethod!),
+                FieldInfo field => BuildFieldSetter(field),
+                _ => throw new($"Unsupported member kind: {member.GetType()}")
+            };
         }
 
         return result;

--- a/src/Excelsior/Reading/SheetReader.cs
+++ b/src/Excelsior/Reading/SheetReader.cs
@@ -35,30 +35,12 @@ class SheetReader<TModel> :
     static IEnumerable<MemberInfo> GetReadableMembers(Type type)
     {
         const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance;
-        foreach (var property in type.GetProperties(flags))
-        {
-            if (!property.IsReadable)
-            {
-                continue;
-            }
-
-            if (property.Attribute<IgnoreAttribute>() != null)
-            {
-                continue;
-            }
-
-            yield return property;
-        }
-
-        foreach (var field in type.GetFields(flags))
-        {
-            if (field.Attribute<IgnoreAttribute>() != null)
-            {
-                continue;
-            }
-
-            yield return field;
-        }
+        return type.GetProperties(flags)
+            .Where(_ => _.IsReadable)
+            .Cast<MemberInfo>()
+            .Concat(type.GetFields(flags))
+            .DistinctByMostDerived()
+            .Where(_ => _.Attribute<IgnoreAttribute>() == null);
     }
 
     static string ResolveHeading(MemberInfo info)


### PR DESCRIPTION
GetProperties/GetFields return inherited members, so a `new`-shadowed member appears twice with the same name. That crashed column registration (Dictionary.Add), and silently clobbered both read-side member discovery and the setter table (base int setter overwriting a derived string one, throwing InvalidCastException on read). Dedup all three to the most-derived declaration so write and read stay consistent.