### PR TITLE
Report read errors at the cell's real file column

### DIFF
--- a/src/Excelsior.Tests/Reading/BookReaderErrorTests.cs
+++ b/src/Excelsior.Tests/Reading/BookReaderErrorTests.cs
@@ -379,4 +379,40 @@ public class BookReaderErrorTests
         Assert.That(errors.Select(_ => _.ColumnName), Is.EqualTo(["Value", "Value", "Value"]));
         Assert.That(errors.Select(_ => _.RowIndex), Is.EqualTo([2, 3, 4]));
     }
+
+    public class ReorderSource
+    {
+        public required string Alpha { get; init; }
+        public required string Beta { get; init; }
+    }
+
+    public class ReorderTarget
+    {
+        // Declared in a different order than the file's physical columns; Beta is physically column B.
+        public int Beta { get; set; }
+        public string Alpha { get; set; } = "";
+    }
+
+    [Test]
+    public async Task ErrorCellReferenceUsesFilePositionNotDeclaredOrder()
+    {
+        // The reader resolves columns by metadata/heading, so the file's physical column order can
+        // differ from the model's declared order. A conversion error must point at the cell's real
+        // column — Beta is physically column B — not its declared ordinal (which would say A).
+        var stream = new MemoryStream();
+        var builder = new BookBuilder();
+        builder.AddSheet<ReorderSource>([new() {Alpha = "a", Beta = "not-a-number"}]);
+        await builder.ToStream(stream);
+        stream.Position = 0;
+
+        var reader = new BookReader();
+        reader.AddSheet<ReorderTarget>();
+        var result = reader.TryConvert(stream);
+
+        Assert.That((bool)result, Is.False);
+        Assert.That(result.Errors, Has.Count.EqualTo(1));
+        var error = result.Errors[0];
+        Assert.That(error.ColumnName, Is.EqualTo("Beta"));
+        Assert.That(error.CellReference, Is.EqualTo("B2"));
+    }
 }

--- a/src/Excelsior/Reading/SheetParser.cs
+++ b/src/Excelsior/Reading/SheetParser.cs
@@ -179,9 +179,17 @@ static class SheetParser
                 }
 
                 fileIndexToSlot = new(columnByIndex.Count);
+                // Inverse map (slot -> file column index). The file's physical column order can
+                // differ from the model's declared order, so an error's cell reference must use the
+                // column's real position in the file, not its declared ordinal. Every slot is
+                // guaranteed a file index here: the loop above aborts if any declared column is
+                // unmatched, so the int[] zero-default is never observed.
+                var slotToFileIndex = new int[columns.Count];
                 foreach (var (fileIndex, column) in columnByIndex)
                 {
-                    fileIndexToSlot[fileIndex] = slotByName[column.Name];
+                    var slot = slotByName[column.Name];
+                    fileIndexToSlot[fileIndex] = slot;
+                    slotToFileIndex[slot] = fileIndex;
                 }
 
                 cellsBySlot = new Cell?[columns.Count];
@@ -193,7 +201,7 @@ static class SheetParser
                 {
                     var col = slotColumns[slot];
                     var rowIndex = currentRow?.RowIndex?.Value ?? 0;
-                    var cellRef = $"{SheetContext.GetColumnLetter(slot)}{rowIndex}";
+                    var cellRef = $"{SheetContext.GetColumnLetter(slotToFileIndex[slot])}{rowIndex}";
                     errors.Add(new(resolvedSheetName, (int)rowIndex, col.Name, cellRef, message));
                 };
 


### PR DESCRIPTION
The per-row error closure built the cell reference from the declared column ordinal, but the reader resolves columns by metadata/heading, so the file's physical order can differ. Errors then named the wrong column letter. Use a slot->fileIndex inverse so the reference reflects the cell's actual position.