### PR TITLE
Auto-size columns and rows in a single pass

### DIFF
--- a/src/Excelsior.Tests/SheetContextTests.cs
+++ b/src/Excelsior.Tests/SheetContextTests.cs
@@ -1,0 +1,21 @@
+[TestFixture]
+public class SheetContextTests
+{
+    [TestCase(0, "A")]
+    [TestCase(1, "B")]
+    [TestCase(25, "Z")]
+    [TestCase(26, "AA")]
+    [TestCase(27, "AB")]
+    [TestCase(51, "AZ")]
+    [TestCase(52, "BA")]
+    [TestCase(701, "ZZ")]
+    [TestCase(702, "AAA")]
+    [TestCase(16383, "XFD")] // Excel's last column
+    public void ColumnLetterAndIndexRoundTrip(int index, string letter)
+    {
+        Assert.That(SheetContext.GetColumnLetter(index), Is.EqualTo(letter));
+        Assert.That(SheetContext.GetColumnIndex(letter), Is.EqualTo(index));
+        // GetColumnIndex must read only the leading letters of a full cell reference.
+        Assert.That(SheetContext.GetColumnIndex($"{letter}42"), Is.EqualTo(index));
+    }
+}

--- a/src/Excelsior/Renderer.cs
+++ b/src/Excelsior/Renderer.cs
@@ -272,15 +272,14 @@ class Renderer<TModel>(
         column.HeadingStyle?.Invoke(style);
     }
 
-    void ResizeColumn(SheetContext sheet, int index, ColumnConfig<TModel> columnConfig)
+    void ResizeColumn(int index, ColumnConfig<TModel> columnConfig, double autoWidth)
     {
         var resultMinColumnWidth = minColumnWidth ?? bookBuilder.DefaultMinColumnWidth;
         var resultMaxColumnWidth = maxColumnWidth ?? bookBuilder.DefaultMaxColumnWidth;
         int width;
         if (columnConfig.Width == null)
         {
-            var doubleWidth = AdjustColumnWidth(sheet, index);
-            width = (int)Math.Round(doubleWidth);
+            width = (int)Math.Round(autoWidth);
             width += 1;
 
             if (columnConfig.IsEnumerable)
@@ -314,11 +313,53 @@ class Renderer<TModel>(
 
     void AutoSizeColumns(SheetContext sheet)
     {
+        var autoWidths = ComputeAutoWidths(sheet);
         for (var index = 0; index < columns.Count; index++)
         {
-            var column = columns[index];
-            ResizeColumn(sheet, index, column);
+            ResizeColumn(index, columns[index], autoWidths.GetValueOrDefault(index, 8d));
         }
+    }
+
+    // One pass over the sheet accumulating the widest rendered content per column. Replaces a
+    // per-column rescan that located each column's cell with a linear FirstOrDefault over the row
+    // (O(rows x columns^2)) with a single O(rows x columns) walk.
+    Dictionary<int, double> ComputeAutoWidths(SheetContext sheet)
+    {
+        var widths = new Dictionary<int, double>();
+        if (columns.All(_ => _.Width != null))
+        {
+            // Every column has an explicit width; there is nothing to measure.
+            return widths;
+        }
+
+        foreach (var row in sheet.SheetData.Elements<Row>())
+        {
+            if (Banner != null &&
+                row.RowIndex?.Value == 1)
+            {
+                // The banner spans every column (merged), so its text must not drive any single
+                // column's width.
+                continue;
+            }
+
+            foreach (var cell in row.Elements<Cell>())
+            {
+                var reference = cell.CellReference?.Value;
+                if (reference == null)
+                {
+                    continue;
+                }
+
+                var estimated = GetCellContentLength(cell) * CharWidthFactor(cell) + 2;
+                var columnIndex = SheetContext.GetColumnIndex(reference);
+                if (estimated > widths.GetValueOrDefault(columnIndex, 8d))
+                {
+                    widths[columnIndex] = estimated;
+                }
+            }
+        }
+
+        return widths;
     }
 
     async Task PopulateData(SheetContext sheet, Cancel cancel)
@@ -614,40 +655,6 @@ class Renderer<TModel>(
                     Reference = reference
                 },
                 sheet.SheetData);
-    }
-
-    double AdjustColumnWidth(SheetContext sheet, int columnIndex)
-    {
-        double maxWidth = 8;
-        var colLetter = SheetContext.GetColumnLetter(columnIndex);
-
-        foreach (var row in sheet.SheetData.Elements<Row>())
-        {
-            if (Banner != null &&
-                row.RowIndex?.Value == 1)
-            {
-                // The banner spans every column (merged), so its text must not drive any single
-                // column's width.
-                continue;
-            }
-
-            var cellRef = colLetter + row.RowIndex;
-            var cell = row.Elements<Cell>()
-                .FirstOrDefault(_ => _.CellReference?.Value == cellRef);
-            if (cell == null)
-            {
-                continue;
-            }
-
-            var length = GetCellContentLength(cell);
-            var estimated = length * CharWidthFactor(cell) + 2;
-            if (estimated > maxWidth)
-            {
-                maxWidth = estimated;
-            }
-        }
-
-        return maxWidth;
     }
 
     double CharWidthFactor(Cell cell)
@@ -1345,18 +1352,16 @@ class Renderer<TModel>(
             }
 
             double maxLines = 1;
-            for (var i = 0; i < columns.Count; i++)
+            foreach (var cell in row.Elements<Cell>())
             {
-                var colLetter = SheetContext.GetColumnLetter(i);
-                var cellRef = colLetter + row.RowIndex;
-                var cell = row.Elements<Cell>()
-                    .FirstOrDefault(_ => _.CellReference?.Value == cellRef);
-                if (cell == null)
+                var reference = cell.CellReference?.Value;
+                if (reference == null)
                 {
                     continue;
                 }
 
-                var width = finalColumnWidths.GetValueOrDefault(i, 8d);
+                var columnIndex = SheetContext.GetColumnIndex(reference);
+                var width = finalColumnWidths.GetValueOrDefault(columnIndex, 8d);
                 var lines = EstimateVisualLines(cell, width);
                 if (lines > maxLines)
                 {

--- a/src/Excelsior/SheetContext.cs
+++ b/src/Excelsior/SheetContext.cs
@@ -52,4 +52,22 @@ public class SheetContext
 
         return result;
     }
+
+    // Inverse of GetColumnLetter: reads the leading column letters of a cell reference (e.g. "AB12")
+    // and returns the 0-based column index. Stops at the first non-letter (the row digits).
+    internal static int GetColumnIndex(string cellReference)
+    {
+        var index = 0;
+        foreach (var character in cellReference)
+        {
+            if (character is < 'A' or > 'Z')
+            {
+                break;
+            }
+
+            index = index * 26 + (character - 'A' + 1);
+        }
+
+        return index - 1;
+    }
 }


### PR DESCRIPTION
AutoSizeColumns and ApplyMaxRowHeight located each column's cell with a linear FirstOrDefault over the row, making both O(rows x columns^2). Walk each row's cells once instead, mapping cell to column via a new GetColumnIndex (inverse of GetColumnLetter) — O(rows x columns). Output is unchanged.