### PR TITLE
Rename DocumentProperties to BookProperties

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1213,7 +1213,7 @@ using var stream = await builder.ToMemoryStream();
 
 The standard fields map onto the workbook's core and extended (app) property parts:
 
-| `DocumentProperties` member | Written to |
+| `BookProperties` member | Written to |
 | --- | --- |
 | `Title`, `Subject`, `Keywords`, `Category`, `Status` | Core properties |
 | `Author` | Core `Creator` |
@@ -1224,7 +1224,7 @@ The standard fields map onto the workbook's core and extended (app) property par
 
 Custom values may be a `string`, `bool`, an integral or floating-point number, `DateTime`, `DateOnly` (`Date`), or `Guid`. Any other value type throws an `ArgumentException` when the workbook is built, so convert it to a supported type first. A `null` value is written as empty text.
 
-The last call to `SetProperties` wins; pass a fresh `DocumentProperties` to replace previously set values.
+The last call to `SetProperties` wins; pass a fresh `BookProperties` to replace previously set values.
 
 #### Reading custom properties
 

--- a/src/Excelsior/BookBuilder.cs
+++ b/src/Excelsior/BookBuilder.cs
@@ -46,7 +46,7 @@ public class BookBuilder
     record SheetMetadata(string SheetName, IReadOnlyList<(int Index, string PropertyName)> Columns, bool HasBanner);
     List<SheetMetadata> sheetMetadata = [];
     string? userMetadataJson;
-    DocumentProperties? documentProperties;
+    BookProperties? documentProperties;
 
     internal void RegisterSheetMetadata(string sheetName, IReadOnlyList<(int Index, string PropertyName)> columns, bool hasBanner) =>
         sheetMetadata.Add(new(sheetName, columns, hasBanner));
@@ -83,10 +83,10 @@ public class BookBuilder
     /// <summary>
     /// Sets the workbook's document properties — the standard fields (title, author, subject, …)
     /// shown in Excel's File &gt; Info pane, plus any user-defined entries in
-    /// <see cref="DocumentProperties.Custom"/>. The last call wins; pass a fresh
-    /// <see cref="DocumentProperties"/> to replace previously set values.
+    /// <see cref="BookProperties.Custom"/>. The last call wins; pass a fresh
+    /// <see cref="BookProperties"/> to replace previously set values.
     /// </summary>
-    public void SetProperties(DocumentProperties properties) =>
+    public void SetProperties(BookProperties properties) =>
         documentProperties = properties;
 
     public ISheetBuilder<TModel> AddSheet<TModel>(

--- a/src/Excelsior/BookProperties.cs
+++ b/src/Excelsior/BookProperties.cs
@@ -7,7 +7,7 @@ namespace Excelsior;
 /// are set get written, so a property left at its default leaves that part of the workbook
 /// untouched.
 /// </summary>
-public class DocumentProperties
+public class BookProperties
 {
     /// <summary>Maps to the core property <c>Title</c>.</summary>
     public string? Title { get; init; }

--- a/src/Excelsior/DocumentPropertiesWriter.cs
+++ b/src/Excelsior/DocumentPropertiesWriter.cs
@@ -3,7 +3,7 @@ using CustomProps = DocumentFormat.OpenXml.CustomProperties;
 using ExtendedProps = DocumentFormat.OpenXml.ExtendedProperties;
 
 /// <summary>
-/// Applies a <see cref="DocumentProperties"/> to a <see cref="SpreadsheetDocument"/>:
+/// Applies a <see cref="BookProperties"/> to a <see cref="SpreadsheetDocument"/>:
 /// core properties go to <c>docProps/core.xml</c> via <see cref="OpenXmlPackage.PackageProperties"/>,
 /// company/manager to the extended part (<c>docProps/app.xml</c>), and the user-defined entries
 /// to the custom part (<c>docProps/custom.xml</c>). The namespace aliasing is isolated here because
@@ -15,7 +15,7 @@ static class DocumentPropertiesWriter
     // The fixed FMTID required on every custom document property by the OOXML spec.
     const string customFormatId = "{D5CDD505-2E9C-101B-9397-08002B2CF9AE}";
 
-    public static void Apply(SpreadsheetDocument document, DocumentProperties properties)
+    public static void Apply(SpreadsheetDocument document, BookProperties properties)
     {
         ApplyCore(document, properties);
         ApplyExtended(document, properties);
@@ -29,7 +29,7 @@ static class DocumentPropertiesWriter
     // OpenXmlPackage.PackageProperties: the latter is backed by the OPC package's intrinsic
     // core-property store, which SpreadsheetDocument.Clone (used by every ToStream/ToFile/ToBytes
     // path) does not copy. A real part is enumerated and cloned like any other.
-    static void ApplyCore(SpreadsheetDocument document, DocumentProperties properties)
+    static void ApplyCore(SpreadsheetDocument document, BookProperties properties)
     {
         if (properties is
             {
@@ -73,7 +73,7 @@ static class DocumentPropertiesWriter
         new XDocument(root).Save(stream);
     }
 
-    static void ApplyExtended(SpreadsheetDocument document, DocumentProperties properties)
+    static void ApplyExtended(SpreadsheetDocument document, BookProperties properties)
     {
         if (properties.Company == null &&
             properties.Manager == null)
@@ -96,7 +96,7 @@ static class DocumentPropertiesWriter
         part.Properties = extended;
     }
 
-    static void ApplyCustom(SpreadsheetDocument document, DocumentProperties properties)
+    static void ApplyCustom(SpreadsheetDocument document, BookProperties properties)
     {
         if (properties.Custom.Count == 0)
         {

--- a/src/Excelsior/Reading/BookReader.cs
+++ b/src/Excelsior/Reading/BookReader.cs
@@ -76,7 +76,7 @@ public class BookReader
 
     /// <summary>
     /// Reads a user-defined custom document property (one set via
-    /// <see cref="DocumentProperties.Custom"/>) and converts its value to
+    /// <see cref="BookProperties.Custom"/>) and converts its value to
     /// <typeparamref name="T"/> — the inverse of <see cref="BookBuilder.SetProperties"/>.
     /// Throws if no property named <paramref name="name"/> is present, or if its value
     /// cannot be converted to <typeparamref name="T"/>. Use
@@ -106,7 +106,7 @@ public class BookReader
 
     /// <summary>
     /// Attempts to read a user-defined custom document property (one set via
-    /// <see cref="DocumentProperties.Custom"/>) and convert its value to
+    /// <see cref="BookProperties.Custom"/>) and convert its value to
     /// <typeparamref name="T"/>. Returns <c>false</c> when no property named
     /// <paramref name="name"/> is present or its value cannot be converted. Names are
     /// matched case-insensitively. Must be called after <see cref="Convert(Stream)"/> or


### PR DESCRIPTION
The name collided with Parchment's type of the same name. The two libraries ship together and their readmes point at each other, so a project writing both Word and Excel imports both namespaces and then cannot name either type unqualified. Parchment is renaming its side in the same change.

BookProperties rather than WorkbookProperties: the latter is already taken by DocumentFormat.OpenXml.Spreadsheet, so it would have traded one collision for a worse one inside this library's own domain. Book also matches the vocabulary already here - BookBuilder, BookReader.

SetProperties keeps its name, and the readme's usage example is target-typed, so neither moves. A clean break with no shim: the failure is a compile error naming the old type, which is obvious and mechanical to fix.